### PR TITLE
Fix several compiler warnings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ blocaled
 --------
 xxxx-xx-xx: version 0.6
 Feature release
+* fix: Fix compiler warnings regarding labels definied but not used
 * feature: have all the error messages from dbus method sent to caller
 * build: update an obsolete macro in configure.ac
 2023-08-30: version 0.5

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ blocaled
 --------
 xxxx-xx-xx: version 0.6
 Feature release
+* fix: Fix compiler warnings regarding unused variables
 * fix: Fix compiler warnings regarding labels definied but not used
 * feature: have all the error messages from dbus method sent to caller
 * build: update an obsolete macro in configure.ac

--- a/NEWS
+++ b/NEWS
@@ -2,10 +2,12 @@ blocaled
 --------
 xxxx-xx-xx: version 0.6
 Feature release
+* fix: Fix compiler warnings regarding dangling elses
 * fix: Fix compiler warnings regarding unused variables
 * fix: Fix compiler warnings regarding labels definied but not used
 * feature: have all the error messages from dbus method sent to caller
 * build: update an obsolete macro in configure.ac
+
 2023-08-30: version 0.5
 Bug fix release
 * fix: double free when there are errors

--- a/src/localed.c
+++ b/src/localed.c
@@ -932,7 +932,7 @@ on_handle_set_locale_authorized_cb (GObject *source_object,
     }
 
     blocaled_locale1_set_locale (locale1, (const gchar * const *) locale);
-  finish:
+  //finish: (not used right now, but keep in case we add other codepaths)
     blocaled_locale1_complete_set_locale (locale1, data->invocation);
 
   unlock:
@@ -1088,7 +1088,7 @@ on_handle_set_vconsole_keyboard_authorized_cb (GObject *source_object,
         }
     }
 
-  finish:
+  //finish: (not used right now, but keep in case we add other codepaths)
     blocaled_locale1_complete_set_vconsole_keyboard (locale1, data->invocation);
 
   unlock:
@@ -1235,7 +1235,7 @@ on_handle_set_x11_keyboard_authorized_cb (GObject *source_object,
         }
     }
 
-  finish:
+  //finish: (not used right now, but keep in case we add other codepaths)
     blocaled_locale1_complete_set_x11_keyboard (locale1, data->invocation);
 
   unlock:

--- a/src/localed.c
+++ b/src/localed.c
@@ -536,7 +536,7 @@ xorg_confd_parser_new (GFile *xorg_confd_file,
 
         entry = xorg_confd_line_entry_new (line, NULL, XORG_CONFD_LINE_TYPE_UNKNOWN);
 
-	if (!finished)
+   if (!finished) {
 	  if (g_regex_match (xorg_confd_line_comment_re, line, 0, &match_info)) {
             g_debug ("Parsed line '%s' as comment", line);
             entry->type = XORG_CONFD_LINE_TYPE_COMMENT;
@@ -585,6 +585,7 @@ xorg_confd_parser_new (GFile *xorg_confd_file,
 
         if (entry->type == XORG_CONFD_LINE_TYPE_END_SECTION && finished)
             parser->section = input_class_section_start;
+   }
 
         continue;
 

--- a/src/localed.c
+++ b/src/localed.c
@@ -222,7 +222,6 @@ kbd_model_map_load (GError **error)
 {
     GList *ret = NULL;
     gchar *filename = NULL, *filebuf = NULL, *line = NULL, *newline = NULL;
-    struct kbd_model_map_entry *entry = NULL;
 
     filename = g_file_get_path (kbd_model_map_file);
     g_debug ("Parsing keyboard model map file file: '%s'", filename);
@@ -858,7 +857,6 @@ on_handle_set_locale_authorized_cb (GObject *source_object,
     struct invoked_locale *data;
     gchar **loc, **var, **val, **locale_values = NULL;
     ShellParser *locale_file_parsed = NULL;
-    gint status = 0;
 
     data = (struct invoked_locale *) user_data;
     if (!check_polkit_finish (res, &err)) {
@@ -1287,7 +1285,6 @@ on_bus_acquired (GDBusConnection *connection,
                  const gchar     *bus_name,
                  gpointer         user_data)
 {
-    gchar *name;
     GError *err = NULL;
 
     g_debug ("Acquired a message bus connection");

--- a/src/main.c
+++ b/src/main.c
@@ -259,13 +259,14 @@ main (gint argc, gchar *argv[])
             g_clear_error (&error);
     } else {
         localeconfig = g_key_file_get_value (key_file, "settings", "localefile", &error);
-        if (error != NULL)
+        if (error != NULL) {
             if (error->code == G_KEY_FILE_ERROR_GROUP_NOT_FOUND) {
 
                 g_critical ("Failed to parse configuration: %s", error->message);
                 return 1;
             } else
                 g_clear_error (&error);
+        }
 
         keyboardconfig = g_key_file_get_value (key_file, "settings", "keymapfile", &error);
         g_clear_error (&error);

--- a/src/shellparser.c
+++ b/src/shellparser.c
@@ -545,7 +545,6 @@ shell_parser_clear_variable (ShellParser *parser,
                              const gchar *variable)
 {
     GList *curr = NULL;
-    gboolean ret = FALSE;
 
     g_assert (parser != NULL);
     g_assert (variable != NULL);

--- a/src/shellparser.c
+++ b/src/shellparser.c
@@ -711,7 +711,7 @@ shell_parser_set_and_save (GFile *file,
     alt_var_name = first_alt_var_name;
     value = first_value;
     do {
-      if (value != NULL && *value != 0)
+      if (value != NULL && *value != 0) {
         if (alt_var_name == NULL) {
             if (!shell_parser_set_variable (parser, var_name, value, TRUE)) {
                 g_propagate_error (error,
@@ -729,6 +729,7 @@ shell_parser_set_and_save (GFile *file,
                     goto out;
             }
         }
+      }
     } while ((var_name = va_arg (ap, const gchar*)) != NULL ?
                  alt_var_name = va_arg (ap, const gchar*), value = va_arg (ap, const gchar*), 1 : 0);
 


### PR DESCRIPTION
This PR fixes several compiler warnings - unused labels, unused variables, and dangling elses. This was tested on a SysV system under GNOME by changing the keyboard layout to fr-latin1 and back to US again, as well as running the test suite.