### PR TITLE
fix: set correct locale for testing under musl (and glibc)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 */
 
 #include <errno.h>
+#include <locale.h>
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
@@ -215,6 +216,8 @@ localed_started ()
 gint
 main (gint argc, gchar *argv[])
 {
+	setlocale(LC_CTYPE, "");
+	
     GError *error = NULL;
     GOptionContext *option_context;
     pid_t pid;

--- a/tests/bad-read-userconf
+++ b/tests/bad-read-userconf
@@ -20,7 +20,7 @@ EOF
 sleep 0.1
 sed -i 's/[^]]*]//' scratch/error
 cmp scratch/error << EOF
-: ERROR: Failed to parse configuration: Key file does not have group ?settings?
+: ERROR: Failed to parse configuration: Key file does not have group “settings”
 EOF
 RES=$?
 

--- a/tests/try-options
+++ b/tests/try-options
@@ -41,7 +41,7 @@ if [ $RES = 0 ]; then
     sleep 0.1
     cmp scratch/help << EOF
 Usage:
-  mylocaled [OPTION?] - locale settings D-Bus service
+  mylocaled [OPTION…] - locale settings D-Bus service
 
 Help Options:
   -h, --help        Show help options


### PR DESCRIPTION
Greetings,

I submit this PR because I had some troubles running the tests of blocaled on a **musl**-based system.

First a bit of context.
I'm currently using Void Linux and during the course of my configuration, I came across a few issues related to keyboard mappings when using KDE plasma under Wayland. I pass the details but it boiled down to missing implementation of **localed** DBus service. I discovered **blocaled** and found this project really cool. After testing it, I decided to try to package it for Void Linux. This is where it all started.

For a package to be accepted into the Void Linux official repository, the packager must ensure that it cross-compiles on multiple platforms using both **glibc** and **musl**. I made the package and could successfully cross-compile on all platforms but some tests were failing when run on a **musl** system. As I'm in no way a programmer, I could find after some troubleshooting that it is due to the fact that some functions of glib library use unicode characters in their output. I speak about  g_key_file_load_from_file‎ and g_option_context_get_help. The latter uses the ellipsis unicode character [at line 716](https://github.com/GNOME/glib/blob/3d53902fc39e0ecdd03e5088cd6e009872d62471/glib/goption.c#L716)

As **glibc** and **musl** use different default locales if `setlocale` is not setup in the program, it leads to different character outputs. **glibc** replaces unicode characters with **?** where **musl** replaces them with **\***.  More info [here](https://www.openwall.com/lists/musl/2021/05/24/9).

This commit sets a correct default locale that makes glibc and musl able to display the correct unicode characters. It also updates the tests to check for the correct characters. I ran all tests successfully afterwards and the compiled program seems to work as before.

Thanks in advance.